### PR TITLE
Fixed the evaluation of the Compensated Parameter, the code there was wrong

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: flowCore
 Title: flowCore: Basic structures for flow cytometry data
-Version: 1.29.16
+Version: 1.29.19
 Author: B. Ellis, P. Haaland, F. Hahne, N. Le Meur, N. Gopalakrishnan, J. Spidlen
 Description: Provides S4 data structures and basic functions to deal with flow
 	     cytometry data. 

--- a/R/eval-methods.R
+++ b/R/eval-methods.R
@@ -503,7 +503,16 @@ setMethod("eval",
                    # Added pseudoinverse (from corpcor) to deal with non-square spectrum matrices
                    if(ncol(spillMat) == nrow(spillMat))
                    {
-                       t(solve(spillMat)[parameter,]%*%t(df[,cols]))
+                       # Josef Spidlen, Nov 14, 2013:
+                       # This code is wrong and went probably unnoticed for some time
+                       # t(solve(spillMat)[parameter,]%*%t(df[,cols]))
+                       # The same issue existed in the compensate method (see flowFrame-accessors.R) and
+                       # has been fixed by "phd" long time ago
+                       tmp <- (df[,cols] %*% solve(spillMat))
+                       # that is the same as tmp <- t(solve(t(spillMat))%*%t(df[,cols]))
+                       # which is essentially what the compensate method is doing.
+                       colnames(tmp) <- cols
+                       tmp[,parameter]
                    }
                    else
                    {


### PR DESCRIPTION
Fixed the evaluation of the Compensated Parameter, the code there was wrong and went probably unnoticed for some time. The wrong code is
t(solve(spillMat)[parameter,]%_%t(df[,cols]))
The same issue existed in the compensate method (see flowFrame-accessors.R) and it has been fixed by "phd" long time ago. The new code is
tmp <- (df[,cols] %_% solve(spillMat))
colnames(tmp) <- cols
tmp[,parameter]
That is the same as tmp <- t(solve(t(spillMat))%*%t(df[,cols]))
which is essentially what the compensate method is doing.
