### PR TITLE
Changed the implementation of the Gating-ML 2.0 ASinH transformation calculation

### DIFF
--- a/R/eval-methods.R
+++ b/R/eval-methods.R
@@ -186,7 +186,25 @@ setMethod(
             parameter <- flowFrameToMatrix(parameter)
             # Gating-ML 2.0 fasinh is defined as
 			# (asinh(x * sinh(M * log(10)) / T) + A * log(10)) / ((M + A) * log(10))
-            (asinh(parameter * sinh(expr@M * log(10)) / expr@T) + expr@A * log(10)) / ((expr@M + expr@A) * log(10))
+            #
+            # (asinh(parameter * sinh(expr@M * log(10)) / expr@T) + expr@A * log(10)) / ((expr@M + expr@A) * log(10))
+            #
+            # The previous 'direct' implementation seems to work just fine for me; however,
+            # Wayne Moore suggested, that following calculation may be more stable:
+            # (it is giving the same results based on my tests)
+            myB = (expr@M + expr@A) * log(10)
+            myC = expr@A * log(10)
+            myA = expr@T / sinh(myB - myC)
+            x = parameter / myA
+            # This formula for the arcsinh loses significance when x is negative
+            # Therefore we take advantage of the fact that sinh is an odd function
+            negative = x < 0
+            x[negative] = -x[negative]
+            asinhx = log(x + sqrt(x * x + 1))
+            result = rep(NA, times=length(asinhx))
+            result[negative] = (myC - asinhx[negative]) / myB
+            result[!negative] = (asinhx[!negative] + myC) / myB
+            result
         }
     }
 )


### PR DESCRIPTION
Changed the implementation of the Gating-ML 2.0 ASinH transformation calculation.
The previous 'direct' implementation seems to work just fine for me; however, Wayne Moore suggested, that this calculation is be more stable. It is giving the same results based on my tests, but I switched to it just in case there are actually cases, where this is preferred over the direct implementation because of some calculation precision issues.
