### PR TITLE
Basic FCS3.1 support.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: flowCore
 Title: flowCore: Basic structures for flow cytometry data
-Version: 1.29.23
+Version: 1.29.24
 Author: B. Ellis, P. Haaland, F. Hahne, N. Le Meur, N. Gopalakrishnan, J. Spidlen
 Description: Provides S4 data structures and basic functions to deal with flow
 	     cytometry data. 

--- a/R/IO.R
+++ b/R/IO.R
@@ -13,7 +13,7 @@ isFCSfile <- function(files)
             con <- file(f, open="rb")
             on.exit(close(con))
             version <- readChar(con, 6)
-            isTRUE(version %in% c("FCS2.0", "FCS3.0"))
+            isTRUE(version %in% c("FCS2.0", "FCS3.0", "FCS3.1"))
         }
         else FALSE
     })
@@ -302,8 +302,8 @@ readFCSheader <- function(con, start=0)
 {
     seek(con, start)
     version <- readChar(con, 6)
-    if(!version %in% c("FCS2.0", "FCS3.0"))
-        stop("This does not seem to be a valid FCS2.0 or FCS3.0 file")
+    if(!version %in% c("FCS2.0", "FCS3.0", "FCS3.1"))
+        stop("This does not seem to be a valid FCS2.0, FCS3.0 or FCS3.1 file")
     
     version <-  substring(version, 4, nchar(version))
     tmp <- readChar(con, 4)
@@ -539,7 +539,7 @@ readFCSdata <- function(con, offsets, x, transformation, which.lines,
              "parameters")
     
     ##for DATA segment exceeding 99,999,999 byte.
-    if(offsets["FCSversion"] == 3){
+    if(offsets["FCSversion"] >= 3){
         realOff <- offsets - offsets[8]
         datastart <- as.numeric(readFCSgetPar(x, "$BEGINDATA"))
         dataend <- as.numeric(readFCSgetPar(x, "$ENDDATA"))


### PR DESCRIPTION
Hi guys,
we are starting to get some FCS3.1 files, which we need to analyse. I used to just manually change the header to FCS3.0, but it seems cleaner to add support for FCS3.1 to flowCore. It is very straightforward as FCS3.0 and FCS3.1 are basically the same as far as flowCore is concerned. There are some additional optional keywords, such as $PnD or $SPILLOVER defined by FCS3.1, but these don't seem to be used much yet, and it shouldn't really affect how the FCS file is read by flowCore anyway.
