### PR TITLE
Fix #157: IO issues resulting from read.FCS w/ column.pattern

### DIFF
--- a/R/IO.R
+++ b/R/IO.R
@@ -1763,9 +1763,14 @@ write.FCS <- function(x, filename, what="numeric", delimiter = "|", endian = "bi
     names(pns) <- sprintf("$P%sS", newid.pns)
     mk <- c(mk, pns)
     
-    #must clear the old $PnX before assigning the new ones since the old ones may not be dropped if fr was subsetted previously
-    # because description<- only update or insert but does not delete the old
-    x@description <- orig.kw[!grepl("\\$P[0-9]+[BERNS]", names(orig.kw))]
+    # Must correct PnX keys for the case that fr was subsetted by bumping them down to be consecutive (like newid)
+    names(newid) <-  gsub("\\$", "", pid)
+    # bump indices on remaining keys down to their new values
+    newnames <- names(x@description)
+    for(i in newid){
+      newnames <- gsub(paste0(names(newid)[[i]], "([a-zA-z])"), paste0("P", i, "\\1"), newnames)
+    }
+    names(x@description) <- newnames
     description(x) <- mk
     
     ## Figure out the offsets based on the size of the initial text section


### PR DESCRIPTION
@mikejiang , @gfinak , you can see the linked issue (#157)  for elaboration, but in short the issue is as follows. If `column.pattern` is used with `read.FCS`, the `description` will retain information for the omitted channels which will then carry forward if the `flowFrame` is subsequently passed to `write.FCS`. This will later cause issues if the resulting FCS is read in again as the indices will "bump down" to overlap with the indices of the previously omitted channels.

I'll call out the particularly problematic line in `write.FCS` in the diff below that results in the user's central issue.

There may also be better ways to handle this or changes that need to be made. Additionally, we may decide that it is not worth the potential ramifications of these changes, hence the PR.