### PR TITLE
Prevent channel duplication in fr_append_cols.

### DIFF
--- a/R/flowFrame-accessors.R
+++ b/R/flowFrame-accessors.R
@@ -14,7 +14,7 @@
 #' 
 #' @param fr A \code{\link[flowCore:flowFrame-class]{flowFrame}}.
 #' @param cols A numeric matrix containing the new data columns to be added.
-#' Must has column names to be used as new channel names.
+#' Must have unique column names to be used as new channel names.
 #' 
 #' @name fr_append_cols
 #' @aliases fr_append_cols
@@ -72,8 +72,8 @@ cols_to_pd <- function(fr, cols){
 	checkClass(cols, "matrix")
 	ncol <- ncol(cols)
 	cn <- colnames(cols)
-	if(length(cn) != ncol)
-		stop("All columns in 'cols' must have colnames!")
+	if(length(cn) != ncol | any(cn %in% colnames(fr)))
+		stop("All columns in 'cols' must have unique colnames!")
 	#add to pdata
 	pd <- pData(parameters(fr))
 	ncol_old <- ncol(fr)

--- a/man/fr_append_cols.Rd
+++ b/man/fr_append_cols.Rd
@@ -10,7 +10,7 @@ fr_append_cols(fr, cols)
 \item{fr}{A \code{\link[flowCore:flowFrame-class]{flowFrame}}.}
 
 \item{cols}{A numeric matrix containing the new data columns to be added.
-Must has column names to be used as new channel names.}
+Must have unique column names to be used as new channel names.}
 }
 \value{
 A \code{\linkS4class{flowFrame}}


### PR DESCRIPTION
Just a minor change to throw an error when attempts are made to add channels that already exist in the flowFrame (i.e. new column names should not exist in the current flowFrame).