### PR TITLE
Future support

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -175,7 +175,7 @@ setGeneric("decompensate",
 ## Generics for apply-like methods
 ## ---------------------------------------------------------------------------
 #' @export
-setGeneric("fsApply",function(x,FUN,...,simplify=TRUE,use.exprs=FALSE)
+setGeneric("fsApply",function(x,FUN,...,simplify=TRUE,use.exprs=FALSE,parallel=FALSE)
            standardGeneric("fsApply"))
 
 #' Methods to apply functions over flowFrame margins

--- a/R/flowSet-accessors.R
+++ b/R/flowSet-accessors.R
@@ -339,6 +339,8 @@ setReplaceMethod("keyword", signature=c("flowSet", "list"),
 #' on the \code{\link[flowCore:flowFrame-class]{flowFrame}} object or the
 #' expression values.
 #' @param \dots optional arguments to \code{FUN}.
+#' @param parallel logical (default: FALSE); should the \code{FUN} be run
+#' in parallel using future.apply (see example).
 #' 
 #' @author B. Ellis
 #' @seealso \code{\link{apply}}, \code{\link{sapply}}
@@ -355,6 +357,10 @@ setReplaceMethod("keyword", signature=c("flowSet", "list"),
 #' #Obtain the median of each parameter in each frame.
 #' fsApply(samp,each_col,median)
 #' 
+#' #Same in parallel.
+#' library(future)
+#' plan(strategy="multiprocess", workers=4)
+#' fsApply(samp,each_col,median, parallel=TRUE)
 #' 
 #' @export
 setMethod("fsApply",

--- a/R/flowSet-accessors.R
+++ b/R/flowSet-accessors.R
@@ -338,9 +338,9 @@ setReplaceMethod("keyword", signature=c("flowSet", "list"),
 #' @param use.exprs logical (default: FALSE); should the \code{FUN} be applied
 #' on the \code{\link[flowCore:flowFrame-class]{flowFrame}} object or the
 #' expression values.
-#' @param \dots optional arguments to \code{FUN}.
 #' @param parallel logical (default: FALSE); should the \code{FUN} be run
 #' in parallel using future.apply (see example).
+#' @param \dots optional arguments to \code{FUN}.
 #' 
 #' @author B. Ellis
 #' @seealso \code{\link{apply}}, \code{\link{sapply}}

--- a/R/flowSet-accessors.R
+++ b/R/flowSet-accessors.R
@@ -326,7 +326,7 @@ setReplaceMethod("keyword", signature=c("flowSet", "list"),
 #' @aliases fsApply fsApply,flowSet,ANY
 #' 
 #' @usage 
-#' fsApply(x, FUN, \dots, simplify=TRUE, use.exprs=FALSE)
+#' fsApply(x, FUN, \dots, simplify=TRUE, use.exprs=FALSE, parallel=FALSE)
 #' 
 #' @param x \code{\link[flowCore:flowSet-class]{flowSet}} to be used
 #' @param FUN the function to be applied to each element of \code{x}
@@ -358,9 +358,9 @@ setReplaceMethod("keyword", signature=c("flowSet", "list"),
 #' fsApply(samp,each_col,median)
 #' 
 #' #Same in parallel.
-#' library(future)
-#' plan(strategy="multiprocess", workers=4)
-#' fsApply(samp,each_col,median, parallel=TRUE)
+#' #library(future)
+#' #plan(strategy="multiprocess", workers=4)
+#' #fsApply(samp,each_col,median, parallel=TRUE)
 #' 
 #' @export
 setMethod("fsApply",
@@ -374,9 +374,9 @@ setMethod("fsApply",
 			if(!is.function(FUN))
 				stop("This is not a function!")
 			if(parallel){
-			  if(!suppressWarnings(require(future.apply))) 
+			  if(!requireNamespace("future.apply", quietly = TRUE))
 			    stop("For parallelization, please install future and future.apply.")
-			  res <- structure(future_lapply(sampleNames(x),function(n) {
+			  res <- structure(future.apply::future_lapply(sampleNames(x),function(n) {
 			    y <- x[[n, returnType = "flowFrame"]]
 			    FUN(if(use.exprs) exprs(y) else y,...)
 			  }),names=sampleNames(x))} else {

--- a/man/fsApply.Rd
+++ b/man/fsApply.Rd
@@ -5,7 +5,7 @@
 \alias{fsApply,flowSet,ANY}
 \title{Apply a Function over values in a flowSet}
 \usage{
-fsApply(x, FUN, \dots, simplify=TRUE, use.exprs=FALSE)
+fsApply(x, FUN, \dots, simplify=TRUE, use.exprs=FALSE, parallel=FALSE)
 }
 \arguments{
 \item{x}{\code{\link[flowCore:flowSet-class]{flowSet}} to be used}
@@ -45,9 +45,9 @@ fsApply(samp,summary)
 fsApply(samp,each_col,median)
 
 #Same run in parallel.
-library(future)
-plan(strategy="multiprocess", workers=4)
-fsApply(samp,each_col,median, parallel=TRUE)
+#library(future)
+#plan(strategy="multiprocess", workers=4)
+#fsApply(samp,each_col,median, parallel=TRUE)
 
 
 }

--- a/man/fsApply.Rd
+++ b/man/fsApply.Rd
@@ -23,14 +23,15 @@ return a matrix).}
 \item{use.exprs}{logical (default: FALSE); should the \code{FUN} be applied
 on the \code{\link[flowCore:flowFrame-class]{flowFrame}} object or the
 expression values.}
+
+\item{parallel}{logical (default: FALSE); should the \code{FUN} be parallelized using future.apply (see examples).}
 }
 \description{
 \code{fsApply}, like many of the \code{apply}-style functions in R, acts as an
 iterator for \code{flowSet} objects, allowing the application of a function
 to either the \code{flowFrame} or the data matrix itself. The output can then
 be reconstructed as either a \code{flowSet}, a list, or a matrix depending on
-options and the type of objects returned.
-}
+options and the type of objects returned.}
 \examples{
 
 fcs.loc <- system.file("extdata",package="flowCore")
@@ -42,6 +43,11 @@ fsApply(samp,summary)
 
 #Obtain the median of each parameter in each frame.
 fsApply(samp,each_col,median)
+
+#Same run in parallel.
+library(future)
+plan(strategy="multiprocess", workers=4)
+fsApply(samp,each_col,median, parallel=TRUE)
 
 
 }


### PR DESCRIPTION
Added new option `parallel` to fsApply. When parallel=TRUE, fsApply calls upon `future.apply::future_lapply` instead of `lapply`.

## Usage

```
library(future)
plan("multiprocess", workers=4)
fsApply(..., parallel=TRUE)
```