### PR TITLE
add missing reference to "$SPILLOVER" keyword

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -421,8 +421,8 @@ checkClass <- function(x, class, length=NULL, verbose=FALSE,
 #'     }
 #'   \item{spillover}{Extract spillover matrix from description slot if
 #'     present. It is equivalent to 
-#'     \code{keyword(x, c("spillover", "SPILL"))}
-#'     Thus will simply return a list of keywords value for "spillover" and "SPILL".
+#'     \code{keyword(x, c("spillover", "SPILL", "$SPILLOVER"))}
+#'     Thus will simply return a list of keywords value for "spillover", "SPILL" and "$SPILLOVER".
 #'     
 #'     \emph{Usage:}
 #'     


### PR DESCRIPTION
The value

```
.spillover_pattern <- c("SPILL", "spillover", "$SPILLOVER")
```

is defined in R/utils.R and controls extracting keywords for `spillover` from the flowFrame.

However, a reference to the `"$SPILLOVER"` value is missing in the docs.

Updated here, thank you!