### PR TITLE
fix Latin encoded keyword in GvHD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-pandoc@v2
-
+      
+      - uses: r-lib/actions/setup-tinytex@v1
+      
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
@@ -39,6 +41,12 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+
+      - name: add more tex pkgs
+        run: |
+          install.packages('tinytex')
+          tinytex:::install_yihui_pkgs()
+        shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,10 +7,10 @@ Authors@R: personList(person("B","Ellis", role = "aut"),
 							 person("Nolwenn", "Le Meur", role = "aut"),
 							 person("Nishant", "Gopalakrishnan", role = "aut"),
 							 person("Josef", "Spidlen", role = "aut"),
-							 person("Mike", "Jiang", role = c("aut","cre"), email = "mike@ozette.ai"),
+							 person("Mike", "Jiang", role = c("aut","cre"), email = "mike@ozette.com"),
 							 person("Greg", "Finak", role = "aut"),
 							 person("Samuel","Granjeaud", role = "ctb"))
-Maintainer: Mike Jiang <mike@ozette.ai>
+Maintainer: Mike Jiang <mike@ozette.com>
 Description: Provides S4 data structures and basic functions to deal with flow
     cytometry data.
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: flowCore
 Title: flowCore: Basic structures for flow cytometry data
-Version: 2.9.0
+Version: 2.9.1
 Authors@R: personList(person("B","Ellis", role = "aut"),
 							 person("Perry", "Haaland", role = "aut"),
 							 person("Florian", "Hahne", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: flowCore
 Title: flowCore: Basic structures for flow cytometry data
-Version: 2.8.0
+Version: 2.9.0
 Authors@R: personList(person("B","Ellis", role = "aut"),
 							 person("Perry", "Haaland", role = "aut"),
 							 person("Florian", "Hahne", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: flowCore
 Title: flowCore: Basic structures for flow cytometry data
-Version: 2.7.1
+Version: 2.8.0
 Authors@R: personList(person("B","Ellis", role = "aut"),
 							 person("Perry", "Haaland", role = "aut"),
 							 person("Florian", "Hahne", role = "aut"),


### PR DESCRIPTION
see https://developer.r-project.org/Blog/public/2022/06/27/why-to-avoid-%5Cx-in-regular-expressions/index.html
In the code base of flowCore, we do not use '\x'  as the regular expression pattern,  rather it is legacy data that contains such encoding ,.e.g.

> library(flowCore)
data("GvHD")
k = keyword(GvHD[[1]])[["CREATOR"]]
k
[1] "CELLQuest\xaa" "3.3"          
sub("^$"," ", k)
Error in sub("^$", " ", k) : input string 1 is invalid

In my opinion this sub operation is legitimate, R shouldn't throw errors on the content that the regular expression is operated on, which isn't the issue of the code per se.

However I did correct this data content anyway simply because it floods the R console with lot of warnings upon loading the data in R operates in a different locale.

so here is what I did
```r
GvHD <- fsApply(GvHD, function(fr){
  k = keyword(fr)[["CREATOR"]]
  keyword(fr)[["CREATOR"]] <- sub("\xaa","", k)
  fr
  })
save(GvHD, file = "../flowCore/data/GvHD.rda",compress = "bzip2")
```

this is what it looks now
```r
> k = keyword(GvHD[[1]])[["CREATOR"]]
> k
[1] "CELLQuest" "3.3"      
```